### PR TITLE
Removed scoreboard dictionary's dependency on PlayerName...

### DIFF
--- a/repository/IngSoft2-Model/BigTalkGame.class.st
+++ b/repository/IngSoft2-Model/BigTalkGame.class.st
@@ -77,7 +77,7 @@ BigTalkGame >> moveCurrentPlayer [
 	
 ]
 
-{ #category : #function }
+{ #category : #private }
 BigTalkGame >> playerMove: aPlayer [
 	scoreboard updatePosition: aPlayer slots: (dice roll)..
 	turn := ((turn * ((turn < (self playersAmount ) ) asBit) )+ 1).
@@ -86,7 +86,7 @@ BigTalkGame >> playerMove: aPlayer [
 
 { #category : #queries }
 BigTalkGame >> playerPosition: aPlayer [ 
-	^scoreboard currentPosition: (aPlayer playerName ).
+	^scoreboard currentPosition: aPlayer.
 ]
 
 { #category : #queries }

--- a/repository/IngSoft2-Model/Board.class.st
+++ b/repository/IngSoft2-Model/Board.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : #Board,
 	#superclass : #Object,
 	#instVars : [
-		'sides',
 		'slots'
 	],
 	#category : #'IngSoft2-Model'

--- a/repository/IngSoft2-Model/LoadedDie.class.st
+++ b/repository/IngSoft2-Model/LoadedDie.class.st
@@ -2,22 +2,22 @@ Class {
 	#name : #LoadedDie,
 	#superclass : #Object,
 	#instVars : [
-		'sides'
+		'rollValue'
 	],
 	#category : #'IngSoft2-Model'
 }
 
 { #category : #'instance creation' }
-LoadedDie class >> withSides: aNumberOfSides [ 
-	^self new initializeUsing: aNumberOfSides.
+LoadedDie class >> rolling: anExpectedRoll [ 
+	^self new initializeUsing: anExpectedRoll.
 ]
 
 { #category : #initialize }
-LoadedDie >> initializeUsing: aNumberOfSides [
-	sides := aNumberOfSides 
+LoadedDie >> initializeUsing: anExpectedRoll [
+	rollValue := anExpectedRoll.
 ]
 
 { #category : #function }
 LoadedDie >> roll [
-	^sides.
+	^rollValue .
 ]

--- a/repository/IngSoft2-Model/Player.class.st
+++ b/repository/IngSoft2-Model/Player.class.st
@@ -2,9 +2,7 @@ Class {
 	#name : #Player,
 	#superclass : #Object,
 	#instVars : [
-		'position',
-		'name',
-		'scoreboard'
+		'name'
 	],
 	#classInstVars : [
 		'position'
@@ -19,7 +17,6 @@ Player class >> named: aName [
 
 { #category : #initialize }
 Player >> initializeWithName: aName [
-	position := 0.
 	name := aName.
 ]
 

--- a/repository/IngSoft2-Model/Scoreboard.class.st
+++ b/repository/IngSoft2-Model/Scoreboard.class.st
@@ -13,52 +13,55 @@ Scoreboard class >> competingPlayers: aCollectionOfPlayers [
 ]
 
 { #category : #initialize }
-Scoreboard >> currentPosition: aPlayerName [
-	^scoreboard at: aPlayerName.
+Scoreboard >> currentPosition: aPlayer [
+	^scoreboard at: aPlayer.
 ]
 
 { #category : #initialize }
-Scoreboard >> initializeWithPlayers: aCollectionOfPlayers [ 
- 	scoreboard := Dictionary new.
-	aCollectionOfPlayers do: 
-		[ :player | scoreboard add: (player playerName) -> (0 ) ].
+Scoreboard >> initializeWithPlayers: aCollectionOfPlayers [
+	scoreboard := Dictionary new.
+	aCollectionOfPlayers
+		do: [ :player | scoreboard at: player put: 0 ]
+]
+
+{ #category : #function }
+Scoreboard >> leader [
+	| topScore leader|
+	topScore := 0.
+	scoreboard
+		associationsDo: [ :score | 
+			topScore < score value
+				ifTrue: [ topScore := score value. leader := score ] ].
+	^ leader
 ]
 
 { #category : #function }
 Scoreboard >> leaderName [
-|topScore topPlayerName| 
-	topScore := 0.
-	scoreboard  associationsDo: 
-		[ :score | (topScore < score value) ifTrue: [topScore := score value. topPlayerName := score key] ].
-	^topPlayerName.
+	^(self leader key) playerName .
 ]
 
 { #category : #function }
 Scoreboard >> leaderScore [
-|topScore | 
-	topScore := 0.
-	scoreboard  associationsDo: 
-		[ :score | (topScore < score value) ifTrue: [topScore := score value] ].
-	^topScore.
+	^ self leader value
 ]
 
 { #category : #function }
-Scoreboard >> playerRank: aPlayer [ 
-	| place aSortedCollectionOfPlayerPositions|
-	
-	aSortedCollectionOfPlayerPositions := SortedCollection withAll: (Set withAll: (scoreboard collect: [:score | score])).
-	place := aSortedCollectionOfPlayerPositions size.
-	
-	aSortedCollectionOfPlayerPositions do: 
-		[ :score | ( (scoreboard at: (aPlayer playerName)) = score )  ifTrue: [^place.] 	ifFalse: [place := place - 1]].
-	
-	
+Scoreboard >> playerRank: aPlayer [
+	| place playerPlaces |
+	playerPlaces := SortedCollection
+		withAll: (Set withAll: scoreboard values).
+	place := playerPlaces size.
+	playerPlaces
+		do: [ :score | 
+			(scoreboard at: aPlayer) = score
+				ifTrue: [ ^ place ]
+				ifFalse: [ place := place - 1 ] ]
 ]
 
 { #category : #function }
 Scoreboard >> updatePosition: aPlayer slots: aNumberOfSlots [
 	|currentPosition|
-	currentPosition := scoreboard  at: (aPlayer playerName ).
+	currentPosition := scoreboard  at: aPlayer.
 	
-	scoreboard add: (aPlayer playerName) -> (currentPosition  + aNumberOfSlots )
+	scoreboard at: aPlayer put: (currentPosition  + aNumberOfSlots )
 ]

--- a/repository/IngSoft2-Tests/DiceTest.class.st
+++ b/repository/IngSoft2-Tests/DiceTest.class.st
@@ -66,8 +66,8 @@ DiceTest >> testRollLoadedDice [
 	"scope: class-variables  &  instance-variables"	
 			
 	| aFourSidedDie aTwoSidedDie someDice|
-	aTwoSidedDie := LoadedDie withSides: 2. 
-	aFourSidedDie := LoadedDie withSides: 4. 
+	aTwoSidedDie := LoadedDie rolling: 2. 
+	aFourSidedDie := LoadedDie rolling: 4. 
 	
 	someDice := Dice with:{(aTwoSidedDie).(aFourSidedDie)}.
 	1 to: 1000 do: [ :iter| self assert: (someDice roll ) equals: 6 ].

--- a/repository/IngSoft2-Tests/GameTest.class.st
+++ b/repository/IngSoft2-Tests/GameTest.class.st
@@ -39,8 +39,8 @@ GameTest >> testAGameWithScoreboard [
 	aDice := Dice with: {(Die withSides: 4)}.
 	aBoard :=Board sized: 2.
 	aGame := BigTalkGame playedBy:  {player1.player2} diceUsed: aDice playedOn: aBoard.
-	self assert: (aGame  playerScore: 'Gaspar') equals: 0 .
-	self assert: (aGame  playerScore: 'Martin') equals: 0 .
+	self assert: (aGame  playerScore: player1 ) equals: 0 .
+	self assert: (aGame  playerScore: player2 ) equals: 0 .
 
 ]
 
@@ -55,8 +55,8 @@ GameTest >> testAGameWithScoreboardMovesForward [
 	aBoard :=Board sized: 2.
 	aGame := BigTalkGame playedBy:  {player1.player2} diceUsed:aDice playedOn: aBoard.
 	aGame playerMove: player1.
-	self assert: ( (aGame  playerScore: 'Gaspar') between:1 and: 4).
-	self assert:  (aGame  playerScore: 'Martin') equals: 0 .
+	self assert: ( (aGame  playerScore: player1 ) between:1 and: 4).
+	self assert:  (aGame  playerScore: player2 ) equals: 0 .
 
 ]
 
@@ -113,7 +113,7 @@ GameTest >> testCheckPlayerPositions [
 	
 	player1 := Player named: 'Gaspar'.
 	player2 := Player named: 'Martin'.
-	aDie := LoadedDie withSides: 4.
+	aDie := LoadedDie rolling: 4.
 	aDice := Dice with:{aDie}.
 	aBoard :=Board sized: 20.
 	aGame := BigTalkGame playedBy:  {player1.player2} diceUsed:aDice playedOn: aBoard.
@@ -233,7 +233,7 @@ GameTest >> testGameFinishedAndStillMovePlayer [
 	player1 := Player named: 'Gaspar'.
 	player2 := Player named: 'Martin'.
 	player3 := Player named: 'Carla'.
-	aDie := LoadedDie withSides: 4.
+	aDie := LoadedDie rolling: 4.
 	aDice := Dice with: { aDie }.
 	aBoard :=Board sized: 4.
 	aGame := BigTalkGame playedBy:  {player1.player2.player3 } diceUsed: aDice playedOn: aBoard.
@@ -249,7 +249,7 @@ GameTest >> testGameFinishedAndStillMovePlayer [
 GameTest >> testGameWithNoPlayers [
 	| aDie aDice aBoard |
 	
-	aDie := LoadedDie withSides: 4.
+	aDie := LoadedDie rolling: 4.
 	aDice := Dice with: { aDie }.
 	aBoard :=Board sized: 4.
 	
@@ -267,7 +267,7 @@ GameTest >> testGameWithTwoPlayersWithSameName [
 	player1 := Player named: 'Gaspar'.
 	player2 := Player named: 'Carla'.
 	player3 := Player named: 'Carla'.
-	aDie := LoadedDie withSides: 4.
+	aDie := LoadedDie rolling: 4.
 	aDice := Dice with: { aDie }.
 	aBoard :=Board sized: 4.
 	
@@ -285,7 +285,7 @@ GameTest >> testGameWithWrongBoardClass [
 	player1 := Player named: 'Gaspar'.
 	player2 := Player named: 'Carla'.
 
-	aDie := LoadedDie withSides: 4.
+	aDie := LoadedDie rolling: 4.
 	aDice := Dice with: { aDie }.
 
 	
@@ -302,7 +302,7 @@ GameTest >> testGameWithWrongDiceClass [
 	
 	player1 := Player named: 'Gaspar'.
 	player2 := Player named: 'Carla'.
-	aDie := LoadedDie withSides: 4.
+	aDie := LoadedDie rolling: 4.
 	aBoard :=Board sized: 4.
 	
 	self should: [ BigTalkGame playedBy:{player1.player2} diceUsed: aDie playedOn: aBoard ] 
@@ -316,7 +316,7 @@ GameTest >> testGameWithWrongDiceClass [
 GameTest >> testGameWithWrongPlayerClass [
 	| aDie aDice aBoard |
 	
-	aDie := LoadedDie withSides: 4.
+	aDie := LoadedDie rolling: 4.
 	aDice := Dice with: { aDie }.
 	aBoard :=Board sized: 4.
 	


### PR DESCRIPTION
Now just uses player as key. 
Changed leaderscore and leadername methods to just use leader message to get the leader
Changed loaded die instance creation message name 
Renamed some methods.